### PR TITLE
updated regexps for arguments

### DIFF
--- a/driver/utils.py
+++ b/driver/utils.py
@@ -214,7 +214,7 @@ class ArgumentListFilter(object):
             r'^.+\.(c|cc|cpp|C|cxx|i|s|S)$' : (0, ArgumentListFilter.inputFileCallback),
             #iam: the object file recogition is not really very robust, object files
             # should be determined by their existance and contents...
-            r'^.+\.(o|so|po|a)$' : (0, ArgumentListFilter.objectFileCallback),
+            r'^.+\.(o|So|so|po|a)$' : (0, ArgumentListFilter.objectFileCallback),
             r'^-(l|L).+$' : (0, ArgumentListFilter.linkUnaryCallback),
             r'^-I.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-D.+$' : (0, ArgumentListFilter.compileUnaryCallback),

--- a/driver/utils.py
+++ b/driver/utils.py
@@ -214,13 +214,12 @@ class ArgumentListFilter(object):
             r'^.+\.(c|cc|cpp|C|cxx|i|s|S)$' : (0, ArgumentListFilter.inputFileCallback),
             #iam: the object file recogition is not really very robust, object files
             # should be determined by their existance and contents...
-            r'^.+\.(o|So|po|a)$' : (0, ArgumentListFilter.objectFileCallback),
+            r'^.+\.(o|so|po|a)$' : (0, ArgumentListFilter.objectFileCallback),
             r'^-(l|L).+$' : (0, ArgumentListFilter.linkUnaryCallback),
             r'^-I.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-D.+$' : (0, ArgumentListFilter.compileUnaryCallback),
-            #iam: hopefully the order of these is preserved, time will tell
             r'^-Wl,.+$' : (0, ArgumentListFilter.linkUnaryCallback),
-            r'^-W.+$' : (0, ArgumentListFilter.compileUnaryCallback),
+            r'^-W(?!l,).*$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-f.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-std=.+$' : (0, ArgumentListFilter.compileUnaryCallback),
         }


### PR DESCRIPTION
Removed typo to find .so files
Order is not kept in dict, fixing the regexp


These changes were tested in several versions of apache, mysql, sqlite, cppcheck, transmission, and some other programs.