### PR TITLE
Update parsedargs to reflect user-defined archiver

### DIFF
--- a/extract-bc
+++ b/extract-bc
@@ -293,6 +293,7 @@ def extract_bc_args(args):
     parsedArgs = parser.parse_args()
 
     inputFile  = parsedArgs.wllvm_binary
+    llvmArchiver = parsedArgs.archiver
     llvmLinker = parsedArgs.linker
     verboseFlag = parsedArgs.verbose
     


### PR DESCRIPTION
This makes extract-bc's archiving behavior consistent with linker for user defined args