### PR TITLE
Added handling for code coverage instrumentation options

### DIFF
--- a/driver/utils.py
+++ b/driver/utils.py
@@ -201,6 +201,9 @@ class ArgumentListFilter(object):
             '-print-multi-lib' : (0, ArgumentListFilter.compileUnaryCallback),
             '-print-libgcc-file-name' : (0, ArgumentListFilter.compileUnaryCallback),
 
+            # Code coverage instrumentation
+            '-fprofile-arcs' : (0, ArgumentListFilter.compileLinkUnaryCallback),
+            '-coverage' : (0, ArgumentListFilter.compileLinkUnaryCallback),
 
             #
             # BD: need to warn the darwin user that these flags will rain on their parade
@@ -376,6 +379,10 @@ class ArgumentListFilter(object):
     def linkBinaryCallback(self, flag, arg):
         self.linkArgs.append(flag)
         self.linkArgs.append(arg)
+
+    def compileLinkUnaryCallback(self, flag):
+        self.compileArgs.append(flag)
+        self.linkArgs.append(flag)
 
     def getOutputFilename(self):
         if self.outputFilename is not None:


### PR DESCRIPTION
Compiling with `-fprofile-arcs` or `-coverage` requires the option to be provided to both the compiling as well as the linking phase. This update supplies the option to both phases.