### PR TITLE
Support the `--coverage` flag

### DIFF
--- a/driver/utils.py
+++ b/driver/utils.py
@@ -204,6 +204,7 @@ class ArgumentListFilter(object):
             # Code coverage instrumentation
             '-fprofile-arcs' : (0, ArgumentListFilter.compileLinkUnaryCallback),
             '-coverage' : (0, ArgumentListFilter.compileLinkUnaryCallback),
+            '--coverage' : (0, ArgumentListFilter.compileLinkUnaryCallback),
 
             #
             # BD: need to warn the darwin user that these flags will rain on their parade


### PR DESCRIPTION
Support a variant of the `-coverage` flag supported by both
the clang and gcc driver.

This is a very straight forward extension to @domainexpert 's work
in fd307bd692c7feef7628756a67fe9ceb0cdc66d0 .