### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![WLLVM](https://github.com/SRI-CSL/whole-program-llvm/blob/master/img/dragon128x128.png?raw_true)Whole Program LLVM
+![WLLVM](img/dragon128x128.png?raw_true)Whole Program LLVM
 ==================
 [![PyPI version](https://badge.fury.io/py/wllvm.svg)](https://badge.fury.io/py/wllvm)
 [![Build Status](https://travis-ci.org/SRI-CSL/whole-program-llvm.svg?branch=master)](https://travis-ci.org/SRI-CSL/whole-program-llvm)
@@ -144,7 +144,7 @@ Tutorials
 ---------
 
 A gentler set of instructions on building apache in a vagrant Ubuntu 14.04 can be found
-[here,](https://github.com/SRI-CSL/whole-program-llvm/blob/master/doc/tutorial.md) and for Ubuntu 16.04 [here.](https://github.com/SRI-CSL/whole-program-llvm/blob/master/doc/tutorial-ubuntu-16.04.md)
+[here,](doc/tutorial.md) and for Ubuntu 16.04 [here.](doc/tutorial-ubuntu-16.04.md)
 
 Building a bitcode module with dragonegg
 ----------------------------------------
@@ -191,7 +191,7 @@ Building an Operating System
 ----------------------------
 
 To see how to build freeBSD 10.0 from scratch check out this
-[guide.](https://github.com/SRI-CSL/whole-program-llvm/blob/master/doc/tutorial-freeBSD.md)
+[guide.](doc/tutorial-freeBSD.md)
 
 
 Configuring without building bitcode
@@ -257,4 +257,4 @@ it might point out what is wrong.
 License
 -------
 
-WLLVM is released under the MIT license. See the file `LICENSE` for [details.](https://github.com/SRI-CSL/whole-program-llvm/blob/master/LICENSE)
+WLLVM is released under the MIT license. See the file `LICENSE` for [details.](LICENSE)

--- a/README.md
+++ b/README.md
@@ -51,9 +51,27 @@ Tutorial
 =======
 If you want to develop or use the development version:
 
-    git clone https://github.com/travitch/whole-program-llvm
-    cd whole-program-llvm
-    pip install -e .
+```
+git clone https://github.com/travitch/whole-program-llvm
+cd whole-program-llvm
+```
+
+Now you need to install WLLVM. You can either install
+globally on your system in develop mode:
+
+```
+sudo pip install -e .
+```
+
+or install WLLVM into a virtual python environment
+in develop mode to avoid installing globally:
+
+```
+virtualenv venv
+source venv/bin/activate
+pip install -e .
+```
+
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Tutorial
 =======
 If you want to develop or use the development version:
 
-    git clone https://github.com/SRI-CSL/whole-program-llvm
+    git clone https://github.com/travitch/whole-program-llvm
     cd whole-program-llvm
     pip install -e .
 


### PR DESCRIPTION
Here are a few doc fixes to avoid pointing at the wrong repository and also mention using `virtualenv` for development.

@ianamason What's the story with TravisCI here? That looks like it's setup for the SRI-CSL repo and  not @travitch 's repository. If they aren't kept in sync this could lead to confusing reports.