### PR TITLE
Add support for -stdlib=.

### DIFF
--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -227,6 +227,7 @@ class ArgumentListFilter(object):
             r'^-W(?!l,).*$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-f.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-std=.+$' : (0, ArgumentListFilter.compileUnaryCallback),
+            r'^-stdlib=.+$' : (0, ArgumentListFilter.compileLinkUnaryCallback),
             r'^-mtune=.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^--sysroot=.+$' :  (0, ArgumentListFilter.compileUnaryCallback),
             r'^-print-prog-name=.*$' : (0, ArgumentListFilter.compileUnaryCallback),


### PR DESCRIPTION
This trivial patch adds support for option "-stdlib=" for clang so that one can build e.g. with "-stdlib=libc++".