### PR TITLE
Add support for FORTRAN code via the brand-new Flang front-end.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
             'wllvm-as = wllvm.as:main',
             'wllvm = wllvm.wllvm:main',
             'wllvm++ = wllvm.wllvmpp:main',
+            'wfortran = wllvm.wfortran:main',
             'wllvm-sanity-checker = wllvm.sanity:main',
             'extract-bc = wllvm.extractor:main',
         ],

--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -213,6 +213,8 @@ class ArgumentListFilter(object):
         #
         defaultArgPatterns = {
             r'^.+\.(c|cc|cpp|C|cxx|i|s|S|bc)$' : (0, ArgumentListFilter.inputFileCallback),
+            # FORTRAN file types
+            r'^.+\.([fF](|[0-9][0-9]|or|OR|pp|PP))$' : (0, ArgumentListFilter.inputFileCallback),
             #iam: the object file recogition is not really very robust, object files
             # should be determined by their existance and contents...
             r'^.+\.(o|lo|So|so|po|a|dylib)$' : (0, ArgumentListFilter.objectFileCallback),

--- a/wllvm/wfortran.py
+++ b/wllvm/wfortran.py
@@ -18,7 +18,7 @@ from .compilers import wcompile
 def main():
     """ The entry point to wllvm.
     """
-    return wcompile("wllvm")
+    return wcompile("wfortran")
 
 
 if __name__ == '__main__':

--- a/wllvm/wllvmpp.py
+++ b/wllvm/wllvmpp.py
@@ -16,7 +16,7 @@ from .compilers import wcompile
 def main():
     """ The entry point to wllvm++.
     """
-    return wcompile(True)
+    return wcompile("wllvm++")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As part of the process, I've had to refactor the code to support more than just
a dual C/C++ codebase. This probably isn't the best means of doing so, but it is
sufficient for getting a working version of fortran compiling. Support for
Dragonegg+gfortran is added as well, but it's completely untested.

The code here is tested with the SPEC CPU2006 benchmark.