### PR TITLE
fix typo in filetype.py

### DIFF
--- a/wllvm/filetype.py
+++ b/wllvm/filetype.py
@@ -44,7 +44,7 @@ class FileType(object):
             retval = cls.MACH_EXECUTABLE
         elif 'ELF' in foutput and 'shared' in foutput:
             retval = cls.ELF_SHARED
-        elif 'Mach-O' in foutput and 'dynamically linked shared' in output:
+        elif 'Mach-O' in foutput and 'dynamically linked shared' in foutput:
             retval = cls.MACH_SHARED
         elif 'current ar archive' in foutput:
             retval = cls.ARCHIVE


### PR DESCRIPTION
This was introduced in https://github.com/travitch/whole-program-llvm/commit/ea42d006c070e0cce23124f034287e0e3fa31bf4 and causes:
```
WARNING::compilers.wcompile() at compilers.py:57 ::wllvm: exception case: a bytes-like object is required, not 'str'
```