### PR TITLE
Add cross-compilation support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ original bitcode file.  For convenience, when using both the manifest
 feature of `extract-bc` and the store, the manifest will contain both
 the original path, and the store path.
 
+Cross-Compilation
+-----------------
+
+To support cross-compilation WLLVM supports the `-target` triple used by clang.
+More information can be found
+[here.](https://clang.llvm.org/docs/CrossCompilation.html#target-triple).
+
+Additionall, WLLVM leverages `objcopy` for some of its heavy lifting. When
+cross-compiling you must ensure to use the appropriate `objcopy` for the target
+architecture. The `BINUTILS_TARGET_PREFIX` environment variable can be used to
+set the objcopy of choice, for example, `arm-linux-gnueabihf`.
 
 Debugging
 ---------

--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -127,6 +127,10 @@ class ArgumentListFilter(object):
             '-iquote' : (1, ArgumentListFilter.compileBinaryCallback),
             '-imultilib' : (1, ArgumentListFilter.compileBinaryCallback),
 
+            # Architecture
+            '-target' : (1, ArgumentListFilter.compileBinaryCallback),
+            '-marm' : (0, ArgumentListFilter.compileUnaryCallback),
+
             # Language
             '-ansi' : (0, ArgumentListFilter.compileUnaryCallback),
             '-pedantic' : (0, ArgumentListFilter.compileUnaryCallback),
@@ -268,6 +272,7 @@ class ArgumentListFilter(object):
             r'-mmacosx-version-min=.+$' :  (0, ArgumentListFilter.compileUnaryCallback),
 
             r'^--sysroot=.+$' :  (0, ArgumentListFilter.compileUnaryCallback),
+            r'^--gcc-toolchain=.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-print-prog-name=.*$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-print-file-name=.*$' : (0, ArgumentListFilter.compileUnaryCallback),
             #iam: -xc from yices. why BD?

--- a/wllvm/compilers.py
+++ b/wllvm/compilers.py
@@ -70,6 +70,9 @@ asDir = os.path.abspath(os.path.join(driverDir, 'dragonegg_as'))
 # Environmental variable for path to compiler tools (clang/llvm-link etc..)
 llvmCompilerPathEnv = 'LLVM_COMPILER_PATH'
 
+# Environmental variable for cross-compilation target.
+binutilsTargetPrefixEnv = 'BINUTILS_TARGET_PREFIX'
+
 # This is the ELF section name inserted into binaries
 elfSectionName = '.llvm_bc'
 
@@ -130,12 +133,15 @@ def attachBitcodePathToObject(bcPath, outFileName):
     os.fsync(f.fileno())
     f.close()
 
+    binUtilsTargetPrefix = os.getenv(binutilsTargetPrefixEnv)
 
     # Now write our bitcode section
     if sys.platform.startswith('darwin'):
-        objcopyCmd = ['ld', '-r', '-keep_private_externs', outFileName, '-sectcreate', darwinSegmentName, darwinSectionName, f.name, '-o', outFileName]
+        objcopyBin = '{}-{}'.format(binUtilsTargetPrefix, 'ld') if binUtilsTargetPrefix else 'ld'
+        objcopyCmd = [objcopyBin, '-r', '-keep_private_externs', outFileName, '-sectcreate', darwinSegmentName, darwinSectionName, f.name, '-o', outFileName]
     else:
-        objcopyCmd = ['objcopy', '--add-section', '{0}={1}'.format(elfSectionName, f.name), outFileName]
+        objcopyBin = '{}-{}'.format(binUtilsTargetPrefix, 'objcopy') if binUtilsTargetPrefix else 'objcopy'
+        objcopyCmd = [objcopyBin, '--add-section', '{0}={1}'.format(elfSectionName, f.name), outFileName]
     orc = 0
 
     # loicg: If the environment variable WLLVM_BC_STORE is set, copy the bitcode
@@ -238,6 +244,7 @@ def getBuilder(cmd, mode):
     compilerEnv = 'LLVM_COMPILER'
     cstring = os.getenv(compilerEnv)
     pathPrefix = os.getenv(llvmCompilerPathEnv) # Optional
+
     _logger.debug('WLLVM compiler using %s', cstring)
     if pathPrefix:
         _logger.debug('WLLVM compiler path prefix "%s"', pathPrefix)

--- a/wllvm/extraction.py
+++ b/wllvm/extraction.py
@@ -50,6 +50,9 @@ def extraction():
 bitCodeArchiveExtension = 'bca'
 moduleExtension = 'bc'
 
+# Environmental variable for cross-compilation target.
+binutilsTargetPrefixEnv = 'BINUTILS_TARGET_PREFIX'
+
 def getSectionSizeAndOffset(sectionName, filename):
     """Returns the size and offset of the section, both in bytes.
 
@@ -57,7 +60,10 @@ def getSectionSizeAndOffset(sectionName, filename):
     to find the given section.  Parses the output,and
     extracts thesize and offset of that section (in bytes).
     """
-    objdumpCmd = ['objdump', '-h', '-w', filename]
+
+    binUtilsTargetPrefix = os.getenv(binutilsTargetPrefixEnv)
+    objdumpBin = '{}-{}'.format(binUtilsTargetPrefix, 'objdump') if binUtilsTargetPrefix else 'objdump'
+    objdumpCmd = [objdumpBin, '-h', '-w', filename]
     objdumpProc = Popen(objdumpCmd, stdout=sp.PIPE)
 
     objdumpOutput = objdumpProc.communicate()[0]


### PR DESCRIPTION
Great tool btw! 
I often find myself using this tool to use the IR for cross-compilation. I've replaced the hardcoded instances of `objcopy` and `objdump` so that one can specify a target prefix. Additionally, I've added support for the `-target` option to pass to `clang`.