### PR TITLE
arglistfilter: Add -grecord-gcc-switches

### DIFF
--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -154,6 +154,7 @@ class ArgumentListFilter(object):
             '-gdwarf-2' : (0, ArgumentListFilter.compileUnaryCallback),
             '-gdwarf-3' : (0, ArgumentListFilter.compileUnaryCallback),
             '-gline-tables-only' : (0, ArgumentListFilter.compileUnaryCallback),
+            '-grecord-gcc-switches': (0, ArgumentListFilter.compileUnaryCallback),
 
             '-p' : (0, ArgumentListFilter.compileUnaryCallback),
             '-pg' : (0, ArgumentListFilter.compileUnaryCallback),


### PR DESCRIPTION
Adds [-grecord-gcc-switches](https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html) to the debugging group. Supported by Clang as well.