### PR TITLE
Incrementally link files if arguments larger than ARG_MAX

### DIFF
--- a/wllvm/extraction.py
+++ b/wllvm/extraction.py
@@ -276,7 +276,7 @@ def linkFiles(pArgs, fileNames):
     linkCmd.append(f'-o={pArgs.outputFile}')
 
     fileNames = map(getBitcodePath, fileNames)
-    fileNames = [x for x in fileNames of x != '']
+    fileNames = [x for x in fileNames if x != '']
 
     # Check the size of the argument string first: If it is larger than the
     # allowed size specified by 'getconf ARG_MAX' we have to link the files


### PR DESCRIPTION
Patch for issue #120:

This patch adds the following changes:
 - If the size of all arguments passed to the LLVM linker overstep the `ARG_MAX `environment variable, we incrementally link all files to circumvent the argument limitation.
 - Instead of using `subprocess.Popen`, we use `subprocess.check_call`, a blocking routine. For a single invocation, there is no difference as the process created by `Popen` has to finish anyway. For incrementally linking files, we have to wait until the previous iteration of the resulting file has been written to. Subsequently, we use the result of the previous linking iteration for the next cycle.