### PR TITLE
Exit if wllvm is invoked from ccache

### DIFF
--- a/wllvm/compilers.py
+++ b/wllvm/compilers.py
@@ -6,6 +6,7 @@ import os
 import sys
 import tempfile
 import hashlib
+import subprocess
 
 from shutil import copyfile
 from .filetype import FileType
@@ -20,6 +21,16 @@ _logger = logConfig(__name__)
 def wcompile(mode):
     """ The workhorse, called from wllvm and wllvm++.
     """
+
+    # Make sure we are not invoked from ccache
+    parentCmd = subprocess.check_output(
+            ['ps', '--no-header', '-o', 'comm', '-p', str(os.getppid())], text=True)
+    if parentCmd.strip() == 'ccache':
+        # The following error message may be invisible in terminal because ccache captures stderr
+        _logger.error('Should not be invoked from ccache')
+        # When ccache detects an error during preprocessing,
+        # it will fall back to running the real compiler (wllvm)
+        sys.exit(-1)
 
     rc = 1
 

--- a/wllvm/compilers.py
+++ b/wllvm/compilers.py
@@ -26,9 +26,10 @@ def wcompile(mode):
     parentCmd = subprocess.check_output(
             ['ps', '--no-header', '-o', 'comm', '-p', str(os.getppid())], text=True)
     if parentCmd.strip() == 'ccache':
-        # The following error message may be invisible in terminal because ccache captures stderr
+        # The following error message is invisible in terminal
+        # when ccache is using its preprocessor mode
         _logger.error('Should not be invoked from ccache')
-        # When ccache detects an error during preprocessing,
+        # When ccache detects an error in the preprocessor mode,
         # it will fall back to running the real compiler (wllvm)
         sys.exit(-1)
 


### PR DESCRIPTION
Invoking wllvm from ccache leads to the problem that bitcode files are not generated in any rebuilds after the initial build, because ccache only caches the normal object files (not caching bitcode files).

This was discussed in issue #117.