### PR TITLE
Improve macOS-specific flag compatibility

### DIFF
--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -129,6 +129,7 @@ class ArgumentListFilter:
             '-isysroot' : (1, ArgumentListFilter.compileBinaryCallback),
             '-iquote' : (1, ArgumentListFilter.compileBinaryCallback),
             '-imultilib' : (1, ArgumentListFilter.compileBinaryCallback),
+            '--sysroot' : (1, ArgumentListFilter.compileBinaryCallback),
 
             # Architecture
             '-target' : (1, ArgumentListFilter.compileBinaryCallback),

--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -196,6 +196,7 @@ class ArgumentListFilter:
             '-dynamiclib' : (0, ArgumentListFilter.linkUnaryCallback),
             '-current_version' : (1, ArgumentListFilter.linkBinaryCallback),
             '-compatibility_version' : (1, ArgumentListFilter.linkBinaryCallback),
+            '-framework' : (1, ArgumentListFilter.linkBinaryCallback),
 
             # dragonegg mystery argument
             '--64' : (0, ArgumentListFilter.compileUnaryCallback),


### PR DESCRIPTION
I noticed a few flag tweaks were needed while using this tool on macOS:

* `--sysroot` can be used either joined or separate (at least with Clang)
* `-framework <name>` was being matched by `-f.+` (which doesn't have a second part)