### PR TITLE
Use macOS-safe `ps` syntax

### DIFF
--- a/wllvm/compilers.py
+++ b/wllvm/compilers.py
@@ -24,7 +24,7 @@ def wcompile(mode):
 
     # Make sure we are not invoked from ccache
     parentCmd = subprocess.check_output(
-            ['ps', '--no-header', '-o', 'comm', '-p', str(os.getppid())], text=True)
+            ['ps', '-o', 'comm=', '-p', str(os.getppid())], text=True)
     if parentCmd.strip() == 'ccache':
         # The following error message is invisible in terminal
         # when ccache is using its preprocessor mode


### PR DESCRIPTION
The `ps` command on macOS doesn't support the `--no-header` option. This changes to the more generally available syntax as part of `-o` which allows setting a custom header via `column=text`, but then disables the header if the `text` part is empty.

Fixes https://github.com/travitch/whole-program-llvm/issues/144