### PR TITLE
Fixes for android and llvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,39 @@ original bitcode file.  For convenience, when using both the manifest
 feature of `extract-bc` and the store, the manifest will contain both
 the original path, and the store path.
 
+
+Exclude bitcode files to link
+-----------------------------
+Sometimes the `extract-bc` will report multiple defination error.
+For example:
+```
+error: Linking globals named '__kvm_timer_set_cntvoff': symbol multiply defined!
+```
+
+If we check the vmlinux, we can see several symbols having this string:
+```
+ffffffc080ff2000 T __kvm_nvhe___kvm_timer_set_cntvoff
+ffffffc080ff5ccc t __kvm_nvhe_handle___kvm_timer_set_cntvoff
+ffffffc08008e89c T __kvm_timer_set_cntvoff
+```
+
+Linux kernel is able to build succeed because objcopy has --prefix-symbols option:
+For example in arch/arm64/kvm/hyp/nvhe/Makefile:
+```
+  cmd_hypcopy = $(OBJCOPY) --prefix-symbols=__kvm_nvhe_ $< $@
+```
+
+But extract-bc doesn't have such info, thus llvm-link failed.
+
+To avoid such error, a flag `EXCLUDE_PATHS` which can be used to exclude bc file or dir
+during llvm-link.
+
+For example:
+```
+    EXCLUDE_PATHS='arch/arm64/kernel/pi arch/arm64/kvm/hyp' extract-bc vmlinux
+```
+
+
 Cross-Compilation
 -----------------
 

--- a/wllvm/extraction.py
+++ b/wllvm/extraction.py
@@ -62,8 +62,7 @@ def getSectionSizeAndOffset(sectionName, filename):
     extracts thesize and offset of that section (in bytes).
     """
 
-    binUtilsTargetPrefix = os.getenv(binutilsTargetPrefixEnv)
-    objdumpBin = f'{binUtilsTargetPrefix}-{"objdump"}' if binUtilsTargetPrefix else 'objdump'
+    objdumpBin = 'objdump'
     objdumpCmd = [objdumpBin, '-h', '-w', filename]
     objdumpProc = Popen(objdumpCmd, stdout=sp.PIPE)
 

--- a/wllvm/extraction.py
+++ b/wllvm/extraction.py
@@ -274,6 +274,23 @@ def linkFiles(pArgs, fileNames):
     fileNames = map(getBitcodePath, fileNames)
     fileNames = [x for x in fileNames if x != '']
 
+    # EXCLUDE_PATH: space-separated paths to exclude from the link list.
+    # If it ends with '.bc', it is treated as a filename, otherwise a path.
+    exclude_paths = os.environ.get('EXCLUDE_PATHS')
+    if exclude_paths is not None:
+        excludes = exclude_paths.split()
+        def exclude(fn):
+            for e in excludes:
+                if e.endswith('.bc'):
+                    if fn.endswith(e):
+                        return True
+                else:
+                    path, _ = os.path.split(fn)
+                    if path.endswith(e):
+                        return True
+            return False
+        fileNames = [x for x in fileNames if not exclude(x)]
+
     # Check the size of the argument string first: If it is larger than the
     # allowed size specified by 'getconf ARG_MAX' we have to link the files
     # incrementally to avoid weird errors.

--- a/wllvm/extraction.py
+++ b/wllvm/extraction.py
@@ -1,3 +1,5 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved
+
 from __future__ import print_function
 
 import os

--- a/wllvm/filetype.py
+++ b/wllvm/filetype.py
@@ -34,7 +34,7 @@ class FileType:
         Maybe we should use python-magic instead?
         """
         retval = None
-        fileP = Popen(['file', os.path.realpath(fileName)], stdout=PIPE)
+        fileP = Popen(['/usr/bin/file', os.path.realpath(fileName)], stdout=PIPE)
         output = fileP.communicate()[0]
         foutput = output.decode()
         foutput = foutput.split(' ', 1)[1] # Strip file path

--- a/wllvm/filetype.py
+++ b/wllvm/filetype.py
@@ -35,7 +35,12 @@ class FileType:
         Maybe we should use python-magic instead?
         """
         retval = None
-        fileP = Popen(['/usr/bin/file', os.path.realpath(fileName)], stdout=PIPE)
+        fpath = 'file'
+        fpaths = ['/usr/bin/file', '/usr/local/bin/file']
+        for p in fpaths:
+            if os.path.exists(p):
+                fpath = p
+        fileP = Popen([fpath, os.path.realpath(fileName)], stdout=PIPE)
         output = fileP.communicate()[0]
         foutput = output.decode()
         foutput = foutput.split(' ', 1)[1] # Strip file path

--- a/wllvm/filetype.py
+++ b/wllvm/filetype.py
@@ -1,3 +1,4 @@
+# Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved
 """ A static class that allows the type of a file to be checked.
 """
 import os


### PR DESCRIPTION
- in android file needs to be aboslute path
- add EXCLUDE_PATHS var to bypass multiple defination error
- use readelf instead of objdump to get section offset and size 