### PR TITLE
Fix "-fpass-plugin=a.so" bug

### DIFF
--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -251,6 +251,7 @@ class ArgumentListFilter:
         # - optimiziation and other flags: -f...
         #
         defaultArgPatterns = {
+            r'^-f.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^.+\.(c|cc|cpp|C|cxx|i|s|S|bc)$' : (0, ArgumentListFilter.inputFileCallback),
             # FORTRAN file types
             r'^.+\.([fF](|[0-9][0-9]|or|OR|pp|PP))$' : (0, ArgumentListFilter.inputFileCallback),
@@ -267,7 +268,6 @@ class ArgumentListFilter:
             r'^-Wl,.+$' : (0, ArgumentListFilter.linkUnaryCallback),
             r'^-W(?!l,).*$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-fsanitize=.+$' : (0, ArgumentListFilter.compileLinkUnaryCallback),
-            r'^-f.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-rtlib=.+$' : (0, ArgumentListFilter.linkUnaryCallback),
             r'^-std=.+$' : (0, ArgumentListFilter.compileUnaryCallback),
             r'^-stdlib=.+$' : (0, ArgumentListFilter.compileLinkUnaryCallback),


### PR DESCRIPTION
Hi,

I noticed wllvm drops the compiler argument `-fpass-plugin=a.so`.
Setting `DUMPING = True` in `wllvm/arglistfilter.py` revealed that the compiler argument was classified as an object file:

`objectFiles: ['-fpass-plugin=a.so']`

The root cause is the following regular expression, which accepts `-fpass-plugin=a.so`:

```
r'^.+\.(o|lo|So|so|po|a|dylib)$' : (0, ArgumentListFilter.objectFileCallback),
```

I've fixed this by changing the order of regular expressions, i.e., 

```
r'^-f.+$' : (0, ArgumentListFilter.compileUnaryCallback),
```

is checked first.


Cheers,
Leon