### PR TITLE
Correct the return code of extract-bc

### DIFF
--- a/wllvm/extractor.py
+++ b/wllvm/extractor.py
@@ -30,10 +30,11 @@ def main():
     """ The entry point to extract-bc.
     """
     try:
-        extraction()
+        rc = extraction()
     except Exception:
+        rc = 1
         pass
-    return 0
+    return rc
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
In previous version, the return code of `extraction` function would be ignored even if `extraction` return non-zero code. I set the return code of `extraction` function can be returned to `__main__` phase.