### PR TITLE
Do not attempt to generate a bitcode files from the null device.

### DIFF
--- a/wllvm/arglistfilter.py
+++ b/wllvm/arglistfilter.py
@@ -370,6 +370,8 @@ class ArgumentListFilter:
         retval = (False, "")
         if os.environ.get('WLLVM_CONFIGURE_ONLY', False):
             retval = (True, "CFG Only")
+        if self.getOutputFilename() == os.devnull:
+            retval = (True, "Output is the null device")
         elif not self.inputFiles:
             retval = (True, "No input files")
         elif self.isEmitLLVM:


### PR DESCRIPTION
Some build systems perform dynamic configuration after the ./configure command and then output to the nul device to test feature support. In these cases, wllvm tried to generate a bitcode file from the null device, leading to an error exit code and making configure fail. For this case, WLLVM_CONFIGURE_ONLY cannot be used, as the feature tests will be performed together with the actual build.

This patch mitigates this error by detecting whether the output file is the null device and then skips bitcode generation.